### PR TITLE
Small fix in documentation and new ``neoyank_disable_write`` variable.

### DIFF
--- a/autoload/neoyank.vim
+++ b/autoload/neoyank.vim
@@ -88,6 +88,7 @@ function! neoyank#_save() abort  "{{{
   if g:neoyank#file == ''
         \ || s:is_sudo()
         \ || s:yank_histories ==# s:yank_histories_old
+        \ || (exists('g:neoyank_disable_write') && g:neoyank_disable_write)
     return
   endif
 

--- a/doc/neoyank.txt
+++ b/doc/neoyank.txt
@@ -86,6 +86,18 @@ g:neoyank#save_registers
 
 		The default value is ['"'].
 
+						*b:neoyank_disable_write*
+g:neoyank_disable_write
+		Set to some nonzero value to prohibit neoyank from saving to
+		the yank history. Intended to prevent leaks from encrypted
+		files to the unencrypted yank history.
+
+		Note: This variable is global. Local variables would not work
+		as the yank history is shared by all buffers.
+
+		Example:
+		autocmd BufWinEnter \(*.asc\|*.gpg\) let g:neoyank_disable = 1
+
 ------------------------------------------------------------------------------
 SOURCES						*neoyank-sources*
 

--- a/doc/neoyank.txt
+++ b/doc/neoyank.txt
@@ -77,8 +77,8 @@ g:neoyank#file
 >
 		let g:neoyank#file = $HOME.'/.vim/yankring.txt'
 <
-						*g:neoyank#registers*
-g:neoyank#registers
+						*g:neoyank#save_registers*
+g:neoyank#save_registers
 		Specify the save registers to yank history.
 
 					*g:unite_source_history_save_registers*


### PR DESCRIPTION
Fixes the documentation of `neoyank#save_registers`.
Introduces new global variable `g:neoyank_disable_write` that prevents any writing of the yank history to prevent information leakage from encrypted files to the unencrypted yank history.
