### PR TITLE
Default register should be "+" or "*" when clipboard is unnamedplus or unnamed

### DIFF
--- a/autoload/neoyank.vim
+++ b/autoload/neoyank.vim
@@ -62,9 +62,19 @@ call s:set_default(
       \ 'g:neoyank#limit', 100,
       \ 'g:unite_source_history_yank_limit')
 
+function! s:default_register_from_clipboard()
+  if &clipboard == 'unnamed'
+    return ["*"]
+  elseif  &clipboard == 'unnamedplus'
+    return ["+"]
+  else
+    return ['"']
+  endif
+endfunction
+
 call s:set_default(
       \ 'g:neoyank#save_registers',
-      \ ['"'],
+      \ s:default_register_from_clipboard(),
       \ 'g:unite_source_history_yank_save_registers')
 "}}}
 

--- a/autoload/neoyank.vim
+++ b/autoload/neoyank.vim
@@ -62,19 +62,19 @@ call s:set_default(
       \ 'g:neoyank#limit', 100,
       \ 'g:unite_source_history_yank_limit')
 
-function! s:default_register_from_clipboard()
+function! neoyank#default_register_from_clipboard()
   if &clipboard == 'unnamed'
-    return ["*"]
+    return "*"
   elseif  &clipboard == 'unnamedplus'
-    return ["+"]
+    return "+"
   else
-    return ['"']
+    return '"'
   endif
 endfunction
 
 call s:set_default(
       \ 'g:neoyank#save_registers',
-      \ s:default_register_from_clipboard(),
+      \ [neoyank#default_register_from_clipboard()],
       \ 'g:unite_source_history_yank_save_registers')
 "}}}
 

--- a/autoload/unite/sources/history_yank.vim
+++ b/autoload/unite/sources/history_yank.vim
@@ -38,7 +38,7 @@ let s:source = {
       \}
 
 function! s:source.gather_candidates(args, context) abort "{{{
-  let registers = split(get(a:args, 0, '"'), '\zs')
+  let registers = split(get(a:args, 0, neoyank#default_register_from_clipboard()), '\zs')
 
   call neoyank#update()
 


### PR DESCRIPTION
I have

``` vim
set clipboard=unnamed
```

in my vimrc.

Neoyank isn't registering yanks when I focus into vim, which make it particularly annoying in cases where the default register ir overridden by the default paste behavior.

Neoyank should just keep track of the + or \* registers when clipboard option is set.
