### PR TITLE
Align yanks with newlines

### DIFF
--- a/autoload/unite/sources/history_yank.vim
+++ b/autoload/unite/sources/history_yank.vim
@@ -25,7 +25,7 @@ function! s:source.gather_candidates(args, context) abort
     let candidates += map(copy(get(
           \ neoyank#_get_yank_histories(), register, [])), "{
           \   'word' : v:val[0],
-          \   'abbr' : printf('%-2d - %s', v:key, v:val[0]),
+          \   'abbr' : printf('%-2d - %s', v:key, substitute(v:val[0], '\n', '&     ', 'g')),
           \   'is_multiline' : 1,
           \   'action__regtype' : v:val[1],
           \   }")


### PR DESCRIPTION
Ensure yanks containing newlines have the same alignment on first and
subsequent lines.

The yank candidates are hard to recognize when you have multiline yanks
because the blocks don't line up like when you yanked them. Apply the
6 space indentation from the yank index to subsequent lines to align
them.

If I yank the above paragraph, it now shows in Unite as:

    0  - The yank candidates are hard to recognize when you have multiline yanks
         because the blocks don't line up like when you yanked them. Apply the
         6 space indentation from the yank index to subsequent lines to align
         them.
